### PR TITLE
Naming and correct signature for the first three members in IApplicationView

### DIFF
--- a/src/VirtualDesktop/Interop/Build10240_0000/.interfaces/IApplicationView.cs
+++ b/src/VirtualDesktop/Interop/Build10240_0000/.interfaces/IApplicationView.cs
@@ -14,11 +14,11 @@ namespace WindowsDesktop.Interop.Build10240
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     public interface IApplicationView
     {
-        void Proc3();
+        void GetIids(out ulong iidCount, out IntPtr iids);
 
-        void Proc4();
+        HString GetRuntimeClassName();
 
-        void Proc5();
+        IntPtr GetTrustLevel();
 
         void SetFocus();
 


### PR DESCRIPTION
Tested on: 
Server 2022 Build: 20346.1906
Windows 11 Build: 22621.2215
Windows 10 Build 19045:3393

This is an unnecessary change, but I don't like seeing methods wrong or unnamed.

IApplicationView is still incomplete but the rest are at the bottom and won't cause harm leaving them out.

Debug symbols from twinui.pcshell.dll:
```
GetIids(unsigned long * __ptr64,struct _GUID * __ptr64 * __ptr64) 
GetRuntimeClassName(struct HSTRING__ * __ptr64 * __ptr64) 
GetTrustLevel(enum TrustLevel * __ptr64) - no need to setup the enum since we are not calling this
```