### PR TITLE
Fix crash on desktop switch

### DIFF
--- a/samples/VirtualDesktop.Showcase/MainWindow.xaml.cs
+++ b/samples/VirtualDesktop.Showcase/MainWindow.xaml.cs
@@ -232,6 +232,7 @@ partial class MainWindow
             {
                 Debug.WriteLine($"Moved: {it.Index} -> {it.Index - 1}");
                 VirtualDesktop.Current.Move(it.Index - 1);
+                return;
             }
         }
     }
@@ -244,6 +245,7 @@ partial class MainWindow
             {
                 Debug.WriteLine($"Moved: {it.Index} -> {it.Index + 1}");
                 VirtualDesktop.Current.Move(it.Index + 1);
+                return;
             }
         }
     }

--- a/src/VirtualDesktop/Interop/Build10240_0000/VirtualDesktopNotificationService.cs
+++ b/src/VirtualDesktop/Interop/Build10240_0000/VirtualDesktopNotificationService.cs
@@ -65,7 +65,7 @@ public class VirtualDesktopNotificationService : ComWrapperBase<IVirtualDesktopN
 
         protected void CurrentChangedCore(object pDesktopOld, object pDesktopNew)
             => this.Notification.CurrentVirtualDesktopChanged(this.Wrap(pDesktopOld), this.Wrap(pDesktopNew));
-        
+
         private IVirtualDesktop Wrap(object desktop)
             => this.Factory.VirtualDesktop(desktop).Interface;
     }

--- a/src/VirtualDesktop/Interop/Build22621_2215/.interfaces/IVirtualDesktopNotification.cs
+++ b/src/VirtualDesktop/Interop/Build22621_2215/.interfaces/IVirtualDesktopNotification.cs
@@ -27,9 +27,9 @@ namespace WindowsDesktop.Interop.Build22621
 
         void VirtualDesktopWallpaperChanged(IVirtualDesktop pDesktop, HString chPath);
         
-        IVirtualDesktop VirtualDesktopSwitched();
+        void VirtualDesktopSwitched(IVirtualDesktop pDesktop);
         
-        IVirtualDesktop RemoteVirtualDesktopConnected();
+        void RemoteVirtualDesktopConnected(IVirtualDesktop pDesktop);
     }
 
     internal class VirtualDesktopNotification : VirtualDesktopNotificationService.EventListenerBase, IVirtualDesktopNotification
@@ -79,14 +79,14 @@ namespace WindowsDesktop.Interop.Build22621
             this.WallpaperChangedCore(pDesktop, chPath);
         }
         
-        public IVirtualDesktop VirtualDesktopSwitched()
+        public void VirtualDesktopSwitched(IVirtualDesktop pDesktop)
         {
-            return this.VirtualDesktopSwitched();
+            //this.VirtualDesktopSwitchedCore(pDesktop);
         }
 
-        public IVirtualDesktop RemoteVirtualDesktopConnected()
+        public void RemoteVirtualDesktopConnected(IVirtualDesktop pDesktop)
         {
-            return this.RemoteVirtualDesktopConnected();
+            //this.RemoteVirtualDesktopConnectedCore(pDesktop);
         }
         
     }

--- a/src/VirtualDesktop/Interop/Build22621_2215/.interfaces/IVirtualDesktopNotification.cs
+++ b/src/VirtualDesktop/Interop/Build22621_2215/.interfaces/IVirtualDesktopNotification.cs
@@ -26,9 +26,9 @@ namespace WindowsDesktop.Interop.Build22621
         void CurrentVirtualDesktopChanged(IVirtualDesktop pDesktopOld, IVirtualDesktop pDesktopNew);
 
         void VirtualDesktopWallpaperChanged(IVirtualDesktop pDesktop, HString chPath);
-        
+
         void VirtualDesktopSwitched(IVirtualDesktop pDesktop);
-        
+
         void RemoteVirtualDesktopConnected(IVirtualDesktop pDesktop);
     }
 
@@ -78,16 +78,16 @@ namespace WindowsDesktop.Interop.Build22621
         {
             this.WallpaperChangedCore(pDesktop, chPath);
         }
-        
+
         public void VirtualDesktopSwitched(IVirtualDesktop pDesktop)
         {
-            //this.VirtualDesktopSwitchedCore(pDesktop);
+            this.SwitchedCore(pDesktop);
         }
 
         public void RemoteVirtualDesktopConnected(IVirtualDesktop pDesktop)
         {
-            //this.RemoteVirtualDesktopConnectedCore(pDesktop);
+            this.RemoteConnectedCore(pDesktop);
         }
-        
+
     }
 }

--- a/src/VirtualDesktop/Interop/Build22621_2215/VirtualDesktopNotificationService.cs
+++ b/src/VirtualDesktop/Interop/Build22621_2215/VirtualDesktopNotificationService.cs
@@ -62,7 +62,7 @@ public class VirtualDesktopNotificationService : ComWrapperBase<IVirtualDesktopN
 
         protected void MovedCore(object pDesktop, int nIndexFrom, int nIndexTo)
             => this.Notification.VirtualDesktopMoved(this.Wrap(pDesktop), nIndexFrom, nIndexTo);
-        
+
         protected void RenamedCore(object pDesktop, HString chName)
             => this.Notification.VirtualDesktopRenamed(this.Wrap(pDesktop), chName);
 
@@ -74,6 +74,12 @@ public class VirtualDesktopNotificationService : ComWrapperBase<IVirtualDesktopN
 
         protected void WallpaperChangedCore(object pDesktop, HString chPath)
             => this.Notification.VirtualDesktopWallpaperChanged(this.Wrap(pDesktop), chPath);
+
+        protected void SwitchedCore(object pDesktop)
+            => this.Notification.VirtualDesktopSwitched(this.Wrap(pDesktop));
+
+        protected void RemoteConnectedCore(object pDesktop)
+            => this.Notification.RemoteVirtualDesktopConnected(this.Wrap(pDesktop));
 
         private IVirtualDesktop Wrap(object desktop)
             => this.Factory.VirtualDesktop(desktop).Interface;

--- a/src/VirtualDesktop/Interop/Proxy/IVirtualDesktopNotification.cs
+++ b/src/VirtualDesktop/Interop/Proxy/IVirtualDesktopNotification.cs
@@ -1,4 +1,6 @@
-﻿namespace WindowsDesktop.Interop.Proxy;
+﻿using System.Diagnostics;
+
+namespace WindowsDesktop.Interop.Proxy;
 
 [ComInterface]
 public interface IVirtualDesktopNotification
@@ -22,4 +24,8 @@ public interface IVirtualDesktopNotification
     void CurrentVirtualDesktopChanged(IVirtualDesktop pDesktopOld, IVirtualDesktop pDesktopNew);
 
     void VirtualDesktopWallpaperChanged(IVirtualDesktop pDesktop, string chPath);
+
+    void VirtualDesktopSwitched(IVirtualDesktop pDesktop);
+
+    void RemoteVirtualDesktopConnected(IVirtualDesktop pDesktop);
 }

--- a/src/VirtualDesktop/Interop/Proxy/IVirtualDesktopNotification.cs
+++ b/src/VirtualDesktop/Interop/Proxy/IVirtualDesktopNotification.cs
@@ -1,5 +1,3 @@
-﻿using System.Diagnostics;
-
 namespace WindowsDesktop.Interop.Proxy;
 
 [ComInterface]

--- a/src/VirtualDesktop/VirtualDesktop.notification.cs
+++ b/src/VirtualDesktop/VirtualDesktop.notification.cs
@@ -78,7 +78,7 @@ partial class VirtualDesktop
     public static event EventHandler<VirtualDesktopSwitchedEventArgs>? Switched;
 
     /// <summary>
-    /// Occurs when a remote desktop is connected. Should be related to Windows 365 Cloud PC: https://www.microsoft.com/store/productId/9N1F85V9T8BN?ocid=pdpshare.
+    /// Occurs when a remote desktop is connected. Should be related to Windows 365 Cloud PC: https://www.microsoft.com/store/productId/9N1F85V9T8BN.
     /// </summary>
     /// <remarks>
     /// See <see cref="CurrentChanged"/> for details.

--- a/src/VirtualDesktop/VirtualDesktop.notification.cs
+++ b/src/VirtualDesktop/VirtualDesktop.notification.cs
@@ -70,6 +70,22 @@ partial class VirtualDesktop
     public static event EventHandler<VirtualDesktopWallpaperChangedEventArgs>? WallpaperChanged;
 
     /// <summary>
+    /// Occurs when a virtual desktop is switched. Seems duplicate to ViewVirtualDesktopChanged, the difference is not yet known. Both are fired when swtiching.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="CurrentChanged"/> for details.
+    /// </remarks>
+    public static event EventHandler<VirtualDesktopSwitchedEventArgs>? Switched;
+
+    /// <summary>
+    /// Occurs when a remote desktop is connected. Should be related to Windows 365 Cloud PC: https://www.microsoft.com/store/productId/9N1F85V9T8BN?ocid=pdpshare.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="CurrentChanged"/> for details.
+    /// </remarks>
+    public static event EventHandler<RemoteVirtualDesktopConnectedEventArgs>? RemoteConnected;
+
+    /// <summary>
     /// Register a listener to receive changes in the application view.
     /// </summary>
     /// <param name="targetHwnd">The target window handle to receive events from. If specify <see cref="IntPtr.Zero"/>, all changes will be delivered.</param>
@@ -101,7 +117,7 @@ partial class VirtualDesktop
 
         public void VirtualDesktopIsPerMonitorChanged(int i)
         {
-            
+
         }
 
 
@@ -132,6 +148,12 @@ partial class VirtualDesktop
 
             WallpaperChanged?.Invoke(this, new VirtualDesktopWallpaperChangedEventArgs(desktop, chPath));
         }
+
+        public void VirtualDesktopSwitched(IVirtualDesktop pDesktop) =>
+            Switched?.Invoke(this, new VirtualDesktopSwitchedEventArgs(pDesktop));
+
+        public void RemoteVirtualDesktopConnected(IVirtualDesktop pDesktop) =>
+            RemoteConnected?.Invoke(this, new RemoteVirtualDesktopConnectedEventArgs(pDesktop));
     }
 
     private class ViewChangedListener

--- a/src/VirtualDesktop/VirtualDesktopEventArgs.cs
+++ b/src/VirtualDesktop/VirtualDesktopEventArgs.cs
@@ -106,3 +106,41 @@ public class VirtualDesktopDestroyEventArgs : EventArgs
     {
     }
 }
+
+/// <summary>
+/// Provides data for the <see cref="VirtualDesktop.Switched" /> event.
+/// </summary>
+public class VirtualDesktopSwitchedEventArgs: EventArgs
+{
+    public VirtualDesktop Desktop { get; }
+
+
+    public VirtualDesktopSwitchedEventArgs(VirtualDesktop desktop)
+    {
+        this.Desktop = desktop;
+    }
+
+    internal VirtualDesktopSwitchedEventArgs(IVirtualDesktop desktop)
+        : this(desktop.ToVirtualDesktop())
+    {
+    }
+}
+
+/// <summary>
+/// Provides data for the <see cref="VirtualDesktop.RemoteConnected" /> event.
+/// </summary>
+public class RemoteVirtualDesktopConnectedEventArgs: EventArgs
+{
+    public VirtualDesktop Desktop { get; }
+
+
+    public RemoteVirtualDesktopConnectedEventArgs(VirtualDesktop desktop)
+    {
+        this.Desktop = desktop;
+    }
+
+    internal RemoteVirtualDesktopConnectedEventArgs(IVirtualDesktop desktop)
+        : this(desktop.ToVirtualDesktop())
+    {
+    }
+}


### PR DESCRIPTION
https://github.com/Slion/VirtualDesktop/issues/15

Referred to the implementation here: https://github.com/hwtnb/VirtualDesktop/blob/102f693f3a076189ca8c25f33cd9918c96365af5/source/VirtualDesktop/Interop/(interfaces)/22621/IVirtualDesktopNotification.cs#L85

Seems like what failed is not `ViewVirtualDesktopChanged` but the new `VirtualDesktopSwitched`, which is also fired when we are switching desktops. Not sure why we have two of them... But anyways, made implementation for it and seems fine now.