### PR TITLE
Target .net 8.0

### DIFF
--- a/samples/VirtualDesktop.Showcase/VirtualDesktop.Showcase.csproj
+++ b/samples/VirtualDesktop.Showcase/VirtualDesktop.Showcase.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-	<TargetFrameworks>net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0</TargetFrameworks>
+	<TargetFrameworks>net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <RootNamespace>VirtualDesktopShowcase</RootNamespace>

--- a/src/VirtualDesktop.WPF/VirtualDesktop.WPF.csproj
+++ b/src/VirtualDesktop.WPF/VirtualDesktop.WPF.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;net5.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;net5.0-windows10.0.19041.0</TargetFrameworks>
 	<PackageId>Slions.VirtualDesktop.WPF</PackageId>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>

--- a/src/VirtualDesktop.WinForms/VirtualDesktop.WinForms.csproj
+++ b/src/VirtualDesktop.WinForms/VirtualDesktop.WinForms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;net5.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;net5.0-windows10.0.19041.0</TargetFrameworks>
 	  <PackageId>Slions.VirtualDesktop.WinForms</PackageId>
     <LangVersion>latest</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/VirtualDesktop/VirtualDesktop.csproj
+++ b/src/VirtualDesktop/VirtualDesktop.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;net5.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;net5.0-windows10.0.19041.0</TargetFrameworks>
 	<PackageId>Slions.VirtualDesktop</PackageId>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
Minor update to target .NET 8.0 with WinRT. I was able to compile and run the sample app with these changes using VS 2022 Community on Windows 11 (10.0.22621 Build 22621)
