### PR TITLE
Fix for Windows 11 versions 22621.3155 and 22631.3155 even if old version generated assembly

### DIFF
--- a/src/VirtualDesktop/Properties/Settings.Designer.cs
+++ b/src/VirtualDesktop/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WindowsDesktop.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -146,6 +146,69 @@ namespace WindowsDesktop.Properties {
         public global::System.Collections.Specialized.StringCollection v_22621_2215 {
             get {
                 return ((global::System.Collections.Specialized.StringCollection)(this["v_22621_2215"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute(@"<?xml version=""1.0"" encoding=""utf-16""?>
+<ArrayOfString xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <string>IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513}</string>
+  <string>IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5}</string>
+  <string>IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}</string>
+  <string>IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA}</string>
+  <string>IVirtualDesktop,{3F07F4BE-B107-441A-AF0F-39D82529072C}</string>
+  <string>IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}</string>
+  <string>IVirtualDesktopManagerInternal,{53F5CA0B-158F-4124-900C-057158060B27}</string>
+  <string>IVirtualDesktopNotification,{B9E5E94D-233E-49AB-AF5C-2B4541C3AADE}</string>
+  <string>IVirtualDesktopNotificationService,{0cd45e71-d927-4f15-8b0a-8fef525337bf}</string>
+  <string>IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}</string>
+</ArrayOfString>")]
+        public global::System.Collections.Specialized.StringCollection v_22621_3155 {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["v_22621_3155"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute(@"<?xml version=""1.0"" encoding=""utf-16""?>
+<ArrayOfString xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <string>IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513}</string>
+  <string>IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5}</string>
+  <string>IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}</string>
+  <string>IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA}</string>
+  <string>IVirtualDesktop,{3F07F4BE-B107-441A-AF0F-39D82529072C}</string>
+  <string>IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}</string>
+  <string>IVirtualDesktopManagerInternal,{A3175F2D-239C-4BD2-8AA0-EEBA8B0B138E}</string>
+  <string>IVirtualDesktopNotification,{B287FA1C-7771-471A-A2DF-9B6B21F0D675}</string>
+  <string>IVirtualDesktopNotificationService,{0cd45e71-d927-4f15-8b0a-8fef525337bf}</string>
+  <string>IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}</string>
+</ArrayOfString>")]
+        public global::System.Collections.Specialized.StringCollection v_22631_2428 {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["v_22631_2428"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute(@"<?xml version=""1.0"" encoding=""utf-16""?>
+<ArrayOfString xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <string>IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513}</string>
+  <string>IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5}</string>
+  <string>IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}</string>
+  <string>IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA}</string>
+  <string>IVirtualDesktop,{3F07F4BE-B107-441A-AF0F-39D82529072C}</string>
+  <string>IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}</string>
+  <string>IVirtualDesktopManagerInternal,{53F5CA0B-158F-4124-900C-057158060B27}</string>
+  <string>IVirtualDesktopNotification,{B9E5E94D-233E-49AB-AF5C-2B4541C3AADE}</string>
+  <string>IVirtualDesktopNotificationService,{0cd45e71-d927-4f15-8b0a-8fef525337bf}</string>
+  <string>IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}</string>
+</ArrayOfString>")]
+        public global::System.Collections.Specialized.StringCollection v_22631_3155 {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["v_22631_3155"]));
             }
         }
     }

--- a/src/VirtualDesktop/Properties/Settings.settings
+++ b/src/VirtualDesktop/Properties/Settings.settings
@@ -92,5 +92,50 @@
   &lt;string&gt;IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}&lt;/string&gt;
 &lt;/ArrayOfString&gt;</Value>
     </Setting>
+    <Setting Name="v_22621_3155" Type="System.Collections.Specialized.StringCollection" Scope="Application">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
+  &lt;string&gt;IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513}&lt;/string&gt;
+  &lt;string&gt;IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5}&lt;/string&gt;
+  &lt;string&gt;IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}&lt;/string&gt;
+  &lt;string&gt;IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktop,{3F07F4BE-B107-441A-AF0F-39D82529072C}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopManagerInternal,{53F5CA0B-158F-4124-900C-057158060B27}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopNotification,{B9E5E94D-233E-49AB-AF5C-2B4541C3AADE}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopNotificationService,{0cd45e71-d927-4f15-8b0a-8fef525337bf}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}&lt;/string&gt;
+&lt;/ArrayOfString&gt;</Value>
+    </Setting>
+    <Setting Name="v_22631_2428" Type="System.Collections.Specialized.StringCollection" Scope="Application">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
+  &lt;string&gt;IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513}&lt;/string&gt;
+  &lt;string&gt;IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5}&lt;/string&gt;
+  &lt;string&gt;IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}&lt;/string&gt;
+  &lt;string&gt;IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktop,{3F07F4BE-B107-441A-AF0F-39D82529072C}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopManagerInternal,{A3175F2D-239C-4BD2-8AA0-EEBA8B0B138E}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopNotification,{B287FA1C-7771-471A-A2DF-9B6B21F0D675}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopNotificationService,{0cd45e71-d927-4f15-8b0a-8fef525337bf}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}&lt;/string&gt;
+&lt;/ArrayOfString&gt;</Value>
+    </Setting>
+    <Setting Name="v_22631_3155" Type="System.Collections.Specialized.StringCollection" Scope="Application">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
+  &lt;string&gt;IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513}&lt;/string&gt;
+  &lt;string&gt;IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5}&lt;/string&gt;
+  &lt;string&gt;IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}&lt;/string&gt;
+  &lt;string&gt;IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktop,{3F07F4BE-B107-441A-AF0F-39D82529072C}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopManagerInternal,{53F5CA0B-158F-4124-900C-057158060B27}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopNotification,{B9E5E94D-233E-49AB-AF5C-2B4541C3AADE}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopNotificationService,{0cd45e71-d927-4f15-8b0a-8fef525337bf}&lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}&lt;/string&gt;
+&lt;/ArrayOfString&gt;</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/VirtualDesktop/Utils/OS.cs
+++ b/src/VirtualDesktop/Utils/OS.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace WindowsDesktop.Utils
 {
-    internal class OS
+    public class OS
     {
         /// <summary>
         /// Return the OS Build number such as: 22621.2215

--- a/src/VirtualDesktop/VirtualDesktop.system.cs
+++ b/src/VirtualDesktop/VirtualDesktop.system.cs
@@ -123,7 +123,11 @@ partial class VirtualDesktop
 
     private static void InitializeCore()
     {
-        _provider.Initialize(_assembly ??= new ComInterfaceAssemblyBuilder(_configuration).GetAssembly());
+        try {
+            _provider.Initialize(_assembly ??= new ComInterfaceAssemblyBuilder(_configuration).GetAssembly());
+        } catch {
+            _provider.Initialize(_assembly = new ComInterfaceAssemblyBuilder(_configuration).CompileNewAssembly());
+        }
 
         _notificationListener?.Dispose();
         _notificationListener = _provider.VirtualDesktopNotificationService.Register(new EventProxy());

--- a/src/VirtualDesktop/app.config
+++ b/src/VirtualDesktop/app.config
@@ -103,6 +103,54 @@
      </ArrayOfString>
     </value>
    </setting>
+   <setting name="v_22621_3155" serializeAs="Xml">
+    <value>
+     <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <string>IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513}</string>
+      <string>IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5}</string>
+      <string>IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}</string>
+      <string>IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA}</string>
+      <string>IVirtualDesktop,{3F07F4BE-B107-441A-AF0F-39D82529072C}</string>
+      <string>IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}</string>
+      <string>IVirtualDesktopManagerInternal,{53F5CA0B-158F-4124-900C-057158060B27}</string>
+      <string>IVirtualDesktopNotification,{B9E5E94D-233E-49AB-AF5C-2B4541C3AADE}</string>
+      <string>IVirtualDesktopNotificationService,{0cd45e71-d927-4f15-8b0a-8fef525337bf}</string>
+      <string>IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}</string>
+     </ArrayOfString>
+    </value>
+   </setting>
+   <setting name="v_22631_2428" serializeAs="Xml">
+    <value>
+     <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <string>IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513}</string>
+      <string>IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5}</string>
+      <string>IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}</string>
+      <string>IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA}</string>
+      <string>IVirtualDesktop,{3F07F4BE-B107-441A-AF0F-39D82529072C}</string>
+      <string>IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}</string>
+      <string>IVirtualDesktopManagerInternal,{A3175F2D-239C-4BD2-8AA0-EEBA8B0B138E}</string>
+      <string>IVirtualDesktopNotification,{B287FA1C-7771-471A-A2DF-9B6B21F0D675}</string>
+      <string>IVirtualDesktopNotificationService,{0cd45e71-d927-4f15-8b0a-8fef525337bf}</string>
+      <string>IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}</string>
+     </ArrayOfString>
+    </value>
+   </setting>
+   <setting name="v_22631_3155" serializeAs="Xml">
+    <value>
+     <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <string>IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513}</string>
+      <string>IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5}</string>
+      <string>IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}</string>
+      <string>IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA}</string>
+      <string>IVirtualDesktop,{3F07F4BE-B107-441A-AF0F-39D82529072C}</string>
+      <string>IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B}</string>
+      <string>IVirtualDesktopManagerInternal,{53F5CA0B-158F-4124-900C-057158060B27}</string>
+      <string>IVirtualDesktopNotification,{B9E5E94D-233E-49AB-AF5C-2B4541C3AADE}</string>
+      <string>IVirtualDesktopNotificationService,{0cd45e71-d927-4f15-8b0a-8fef525337bf}</string>
+      <string>IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}</string>
+     </ArrayOfString>
+    </value>
+   </setting>
   </WindowsDesktop.Properties.Settings>
 	</applicationSettings>
 </configuration>


### PR DESCRIPTION
To apply this you would undo last commit f74f597253b78e153c71842d598dbcb2d682d93c and apply this.

I tried and failed to make this 2 PRs one for the app.config / settings changes and one for the recompile on load failure. Seems impossible to because I also have a fork from Grabacr07 and it keeps wanting to reference that (unless I delete it and I don't want to, even archive didn't work)