### PR TITLE
Feature: added windows 10 ltsc 19044.4355 COM object IDs

### DIFF
--- a/src/VirtualDesktop/Properties/Settings.Designer.cs
+++ b/src/VirtualDesktop/Properties/Settings.Designer.cs
@@ -211,5 +211,26 @@ namespace WindowsDesktop.Properties {
                 return ((global::System.Collections.Specialized.StringCollection)(this["v_22631_3155"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute(@"<?xml version=""1.0"" encoding=""utf-16""?>
+<ArrayOfString xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"">
+  <string>IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513} </string>
+  <string>IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5} </string>
+  <string>IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9} </string>
+  <string>IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA} </string>
+  <string>IVirtualDesktop,{FF72FFDD-BE7E-43FC-9C03-AD81681E88E4} </string>
+  <string>IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B} </string>
+  <string>IVirtualDesktopManagerInternal,{F31574D6-B682-4CDC-BD56-1827860ABEC6} </string>
+  <string>IVirtualDesktopNotification,{C179334C-4295-40D3-BEA1-C654D965605A} </string>
+  <string>IVirtualDesktopNotificationService,{0CD45E71-D927-4F15-8B0A-8FEF525337BF} </string>
+  <string>IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F} </string>
+</ArrayOfString>")]
+        public global::System.Collections.Specialized.StringCollection v_19044_4355 {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["v_19044_4355"]));
+            }
+        }
     }
 }

--- a/src/VirtualDesktop/Properties/Settings.settings
+++ b/src/VirtualDesktop/Properties/Settings.settings
@@ -137,5 +137,20 @@
   &lt;string&gt;IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F}&lt;/string&gt;
 &lt;/ArrayOfString&gt;</Value>
     </Setting>
+    <Setting Name="v_19044_4355" Type="System.Collections.Specialized.StringCollection" Scope="Application">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
+  &lt;string&gt;IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513} &lt;/string&gt;
+  &lt;string&gt;IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5} &lt;/string&gt;
+  &lt;string&gt;IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9} &lt;/string&gt;
+  &lt;string&gt;IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA} &lt;/string&gt;
+  &lt;string&gt;IVirtualDesktop,{FF72FFDD-BE7E-43FC-9C03-AD81681E88E4} &lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B} &lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopManagerInternal,{F31574D6-B682-4CDC-BD56-1827860ABEC6} &lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopNotification,{C179334C-4295-40D3-BEA1-C654D965605A} &lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopNotificationService,{0CD45E71-D927-4F15-8B0A-8FEF525337BF} &lt;/string&gt;
+  &lt;string&gt;IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F} &lt;/string&gt;
+&lt;/ArrayOfString&gt;</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/VirtualDesktop/app.config
+++ b/src/VirtualDesktop/app.config
@@ -151,6 +151,22 @@
           </ArrayOfString>
         </value>
       </setting>
+      <setting name="v_19044_4355" serializeAs="Xml">
+        <value>
+          <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <string>IApplicationView,{372E1D3B-38D3-42E4-A15B-8AB2B178F513} </string>
+            <string>IApplicationViewCollection,{1841C6D7-4F9D-42C0-AF41-8747538F10E5} </string>
+            <string>IObjectArray,{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9} </string>
+            <string>IServiceProvider,{6D5140C1-7436-11CE-8034-00AA006009FA} </string>
+            <string>IVirtualDesktop,{FF72FFDD-BE7E-43FC-9C03-AD81681E88E4} </string>
+            <string>IVirtualDesktopManager,{A5CD92FF-29BE-454C-8D04-D82879FB3F1B} </string>
+            <string>IVirtualDesktopManagerInternal,{F31574D6-B682-4CDC-BD56-1827860ABEC6} </string>
+            <string>IVirtualDesktopNotification,{C179334C-4295-40D3-BEA1-C654D965605A} </string>
+            <string>IVirtualDesktopNotificationService,{0CD45E71-D927-4F15-8B0A-8FEF525337BF} </string>
+            <string>IVirtualDesktopPinnedApps,{4CE81583-1E4C-4632-A621-07A53543148F} </string>
+          </ArrayOfString>
+        </value>
+      </setting>
     </WindowsDesktop.Properties.Settings>
   </applicationSettings>
 </configuration>


### PR DESCRIPTION
This PR adds COM object IDs required for Windows 10 LTSC - 10.0.19044.4355.
Tested with gracious help of @Aftergit - https://github.com/hass-agent/HASS.Agent/issues/86 